### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,8 +12,8 @@ ArduinoSerialProtocol	KEYWORD1
 #######################################
 sendData	KEYWORD2
 readData	KEYWORD2
-setSerial KEYWORD2
-srialAvailable  KEYWORD2
+setSerial	KEYWORD2
+srialAvailable	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
@@ -23,4 +23,4 @@ NO_DATA	LITERAL1
 INVALID_SIZE	LITERAL1
 INVALID_CHECKSUM	LITERAL1
 WAITING_FOR_DATA	LITERAL1
-SUCCESS LITERAL1
+SUCCESS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords